### PR TITLE
EDLY-2185: set height of video element to 607 because its width is 1080

### DIFF
--- a/video_xblock/static/css/videojs.css
+++ b/video_xblock/static/css/videojs.css
@@ -11,7 +11,6 @@ body {
 .video-js .vjs-control-bar {
     background-color: #282C2E;
     display: flex;
-    margin-bottom: -30px;
     color: #CFD8DC;
     height: 40px;
 }

--- a/video_xblock/static/html/brightcove.html
+++ b/video_xblock/static/html/brightcove.html
@@ -7,12 +7,11 @@
         data-application-id
         data-setup='{"playbackRates": [0.5, 1.0, 1.5, 2.0] }'
         width="100%"
-        height="560"
+        height="607"
         class="video-js"
         brightcove
         controls
     >
-    <!-- height="560" it's height of iframe minus height of control bar -->
       {{ transcripts }}
     </video>
     <script src="{{ brightcove_js_url }}"></script>

--- a/video_xblock/static/html/html5.html
+++ b/video_xblock/static/html/html5.html
@@ -2,10 +2,9 @@
   id="{{ video_player_id }}"
   class="video-js vjs-default-skin"
   controls
-  height="560"
+  height="607"
   data-setup='{{ data_setup }}'
 >
-<!-- height="560" it's height of iframe minus height of control bar -->
   {{ transcripts }}
 </video>
 <div id="transcript"></div>

--- a/video_xblock/static/html/student_view.html
+++ b/video_xblock/static/html/student_view.html
@@ -9,7 +9,7 @@
     mozallowfullscreen
     webkitallowfullscreen
     width="100%"
-    height="600px"
+    height="607px"
 >
 </iframe>
 <ul class="wrapper-downloads-custom">

--- a/video_xblock/static/html/vimeo.html
+++ b/video_xblock/static/html/vimeo.html
@@ -2,10 +2,9 @@
   id="{{ video_player_id }}"
   class="video-js vjs-default-skin"
   controls
-  height="560"
+  height="607"
   data-setup='{{ data_setup }}'
 >
-<!-- height="560" it's height of iframe minus height of control bar -->
   {{ transcripts }}
 </video>
 <div id="transcript"></div>

--- a/video_xblock/static/html/wistiavideo.html
+++ b/video_xblock/static/html/wistiavideo.html
@@ -3,10 +3,9 @@
   src=""
   class="video-js vjs-default-skin"
   controls
-  height="560"
+  height="607"
   data-setup='{{ data_setup }}'
 >
-<!-- height="560" it's height of iframe minus height of control bar -->
   {{ transcripts }}
 </video>
 <div id="transcript"></div>

--- a/video_xblock/static/html/youtube.html
+++ b/video_xblock/static/html/youtube.html
@@ -2,10 +2,9 @@
   id="{{ video_player_id }}"
   class="video-js vjs-default-skin"
   controls
-  height="560"
+  height="607"
   data-setup='{{ data_setup }}'
 >
-<!-- height="560" it's height of iframe minus height of control bar -->
   {{ transcripts }}
 </video>
 <div id="transcript"></div>


### PR DESCRIPTION
set height of video element to 607 because its width is 1080.According to aspect ratio of 16:9 height should be 607px.